### PR TITLE
Feature: enable overridable character map

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,30 @@ import {CharacterMap} from 'react-character-map';
 
 ```js
 // Use the element;
-<CharacterMap onSelect={function(char,el){ console.log(char, el); }} />
+<CharacterMap
+	characterData={optionalCustomCharacterData}
+	onSelect={function(char,el){ console.log(char, el); }}
+/>
 ```
 
 
 ### Properties
 
-The only property on the element is the `onSelect` callback. This is fired when the user clicks on a character, and has two parameters;
+* `characterData` is an optional property that overrides the default character map. `characterData` should be provided in the form:
+```js
+{
+    "TAB NAME": [
+        { "entity": "&copy;", "hex": "&#00A9;", "name": "COPYRIGHT SIGN", "char": "©" } // char is required
+    ],
+
+
+    "ANOTHER TAB": [
+        { MORE CHARACTER DATA }
+    ]
+}
+
+```
+* `onSelect` callback: This is fired when the user clicks on a character, and has two parameters;
 
 ```js
 onSelect(char, el)

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -31,17 +31,18 @@ class CharacterMap extends React.Component {
         var self = this;
         var categoryList = [];
         var i = -1;
-
+        var { passedChars } = this.props;
+        var characters = passedChars || Chars;
         // Loop through each category
-        var charList = Object.keys(Chars).map(function(category, current) {
+        var charList = Object.keys(characters).map(function(category, current) {
             i++;
 
             if ( parseInt(self.state.active,10) === i ) {
                 // In the active category, loop through the characters and create the list
-                var currentItems = Object.keys(Chars[category]).map(function(p,c){
+                var currentItems = Object.keys(characters[category]).map(function(p,c){
                     return (<li key={'topli' + p}>
-                        <a data-hex={Chars[category][p].hex}  data-entity={Chars[category][p].entity}  data-char={Chars[category][p].char} data-title={Chars[category][p].name}  onClick={ ((e) => self.charClickHandler(e,Chars[category][p])) }>
-                        {Chars[category][p].char}
+                        <a data-hex={characters[category][p].hex}  data-entity={characters[category][p].entity}  data-char={characters[category][p].char} data-title={characters[category][p].name}  onClick={ ((e) => self.charClickHandler(e,characters[category][p])) }>
+                        {characters[category][p].char}
                         </a>
                     </li>);
                 });
@@ -59,7 +60,6 @@ class CharacterMap extends React.Component {
                 </ul>
             </li>);
         });
-
 
         return (
             <div className="charMap--container">

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -31,8 +31,8 @@ class CharacterMap extends React.Component {
         var self = this;
         var categoryList = [];
         var i = -1;
-        var { passedChars } = this.props;
-        var characters = passedChars || Chars;
+        var { characterData } = this.props;
+        var characters = characterData || Chars;
         // Loop through each category
         var charList = Object.keys(characters).map(function(category, current) {
             i++;

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -17,7 +17,7 @@ class CharacterMap extends React.Component {
     }
 
     clickCategoryHandler(e) {
-        const cat = e.target.getAttribute('data-category-index');
+        var cat = e.target.getAttribute('data-category-index');
         this.setState({ active: cat });
     }
 
@@ -28,19 +28,18 @@ class CharacterMap extends React.Component {
     }
 
     render() {
-        const self = this;
-        const categoryList = [];
-        let i = -1;
-        const { characterData } = this.props;
-        const characters = characterData || Chars;
-        let currentItems;
+        var self = this;
+        var categoryList = [];
+        var i = -1;
+        var { characterData } = this.props;
+        var characters = characterData || Chars;
         // Loop through each category
-        const charList = Object.keys(characters).map(function(category, current) {
+        var charList = Object.keys(characters).map(function(category, current) {
             i++;
 
             if ( parseInt(self.state.active,10) === i ) {
                 // In the active category, loop through the characters and create the list
-                currentItems = Object.keys(characters[category]).map(function(p,c){
+                var currentItems = Object.keys(characters[category]).map(function(p,c){
                     return (<li key={'topli' + p}>
                         <a data-hex={characters[category][p].hex}  data-entity={characters[category][p].entity}  data-char={characters[category][p].char} data-title={characters[category][p].name}  onClick={ ((e) => self.charClickHandler(e,characters[category][p])) }>
                         {characters[category][p].char}


### PR DESCRIPTION
## Description
* Enable passing a `characterData` prop to the `CharacterMap` component to override the default data for the tabs and characters to display.

## Use case
The huge number of characters in the character map are fantastic, however some sites may really only want a smaller (or much smaller) set of tabs and characters to be available. 

## Example use
```
import myCharacterData from './chars.json';

<CharacterMap characterData={ myCharacterData }/>
```

