### PR TITLE
Allow hardcoded text to be overidden via props

### DIFF
--- a/dist/component/CharacterMap.js
+++ b/dist/component/CharacterMap.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -175,6 +177,27 @@ var CharacterMap = function (_React$Component) {
             this.setState({ search: search });
         }
     }, {
+        key: 'getCategoryName',
+        value: function getCategoryName(category) {
+            /**
+             * The categoryNames prop is expected to be a JavaScript object with translated category names corresponding
+             * to the object keys in chars.json. Keys are the untranslated names from chars.json; values are the translated
+             * names.
+             */
+            var categoryNames = this.props.categoryNames;
+
+
+            if (!categoryNames || 'object' !== (typeof categoryNames === 'undefined' ? 'undefined' : _typeof(categoryNames))) {
+                return category;
+            }
+
+            if (!(category in categoryNames) || 'string' !== typeof categoryNames[category]) {
+                return category;
+            }
+
+            return categoryNames[category];
+        }
+    }, {
         key: 'charListFromCharacters',
         value: function charListFromCharacters(characters, active) {
             var self = this;
@@ -216,7 +239,7 @@ var CharacterMap = function (_React$Component) {
                             'data-category-index': i,
                             onClick: self.clickCategoryHandler
                         },
-                        category
+                        self.getCategoryName(category)
                     )
                 ));
 
@@ -244,6 +267,11 @@ var CharacterMap = function (_React$Component) {
                 charList = _state2.charList,
                 search = _state2.search;
 
+
+            var filterLabelText = this.props.filterLabelText || 'Filter';
+            var categoriesLabelText = this.props.categoriesLabelText || 'Categories';
+            var characterListLabelText = this.props.characterListLabelText || 'Character List';
+
             return _react2.default.createElement(
                 'div',
                 { className: 'charMap--container' },
@@ -253,12 +281,12 @@ var CharacterMap = function (_React$Component) {
                     _react2.default.createElement(
                         'label',
                         { 'for': 'filter' },
-                        'Filter: '
+                        filterLabelText + ': '
                     ),
                     _react2.default.createElement('input', {
                         type: 'text',
                         name: 'filter',
-                        'aria-label': 'Filter',
+                        'aria-label': filterLabelText,
                         value: search,
                         onChange: this.handleSearchChange,
                         autoComplete: false
@@ -266,12 +294,12 @@ var CharacterMap = function (_React$Component) {
                 ),
                 '' === search && _react2.default.createElement(
                     'ul',
-                    { className: 'charMap--category-menu', 'aria-label': 'Categories' },
+                    { className: 'charMap--category-menu', 'aria-label': categoriesLabelText },
                     categoryList
                 ),
                 _react2.default.createElement(
                     'ul',
-                    { className: 'charMap--categories', 'aria-label': 'Character List' },
+                    { className: 'charMap--categories', 'aria-label': characterListLabelText },
                     charList
                 )
             );

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -118,6 +118,25 @@ class CharacterMap extends React.Component {
         this.setState({search});
     }
 
+    getCategoryName(category) {
+        /**
+         * The categoryNames prop is expected to be a JavaScript object with translated category names corresponding
+         * to the object keys in chars.json. Keys are the untranslated names from chars.json; values are the translated
+         * names.
+         */
+        const { categoryNames } = this.props;
+
+        if (!categoryNames || 'object' !== typeof categoryNames) {
+            return category;
+        }
+
+        if (!(category in categoryNames) || 'string' !== typeof categoryNames[category]) {
+            return category;
+        }
+
+        return categoryNames[category];
+    }
+
     charListFromCharacters(characters, active) {
         var self = this;
         var categoryList = [];
@@ -148,7 +167,7 @@ class CharacterMap extends React.Component {
                     data-category-index={i}
                     onClick={ self.clickCategoryHandler }
                 >
-                    {category}
+                    {self.getCategoryName(category)}
                 </button>
             </li>));
 
@@ -170,25 +189,30 @@ class CharacterMap extends React.Component {
 
     render() {
         const {categoryList,charList,search} = this.state;
+
+        const filterLabelText = this.props.filterLabelText || 'Filter';
+        const categoriesLabelText = this.props.categoriesLabelText || 'Categories';
+        const characterListLabelText = this.props.characterListLabelText || 'Character List';
+
         return (
             <div className="charMap--container">
                 <ul className="charMap--filter">
-                    <label for="filter">Filter: </label>
+                    <label for="filter">{`${filterLabelText}: `}</label>
                     <input
                         type="text"
                         name="filter"
-                        aria-label="Filter"
+                        aria-label={filterLabelText}
                         value={search}
                         onChange={this.handleSearchChange}
                         autoComplete={false}
                     />
                 </ul>
                 { '' === search &&
-                    <ul className="charMap--category-menu" aria-label="Categories">
+                    <ul className="charMap--category-menu" aria-label={categoriesLabelText}>
                         { categoryList}
                     </ul>
                 }
-                <ul className="charMap--categories"  aria-label="Character List">
+                <ul className="charMap--categories"  aria-label={characterListLabelText}>
                     { charList }
                 </ul>
              </div>


### PR DESCRIPTION
This would resolve #15 by allowing the bits of previously hardcoded text in the CharacterMap component to be overridden via props. If they are not overridden, the existing text stays as is. The props are not required, so this would be a 100% backward-compatible change. 

For reference, here's the PR that would integrate this update in 10up's Insert Special Character's plugin: https://github.com/10up/insert-special-characters/pull/63 