### PR TITLE
Focus search input on mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ import {CharacterMap} from 'react-character-map';
 
 ### Properties
 
+* `autofocus` (boolean): When `autofocus` is true, the component's search input will be focused on mount. Default: `true`.
+
 * `characterData` is an optional property that overrides the default character map. `characterData` should be provided in the form:
 ```js
 {

--- a/dist/component/CharacterMap.js
+++ b/dist/component/CharacterMap.js
@@ -49,6 +49,10 @@ var CharacterMap = function (_React$Component) {
         _this.handleSearchChange = _this.handleSearchChange.bind(_this);
         _this.clickCategoryHandler = _this.clickCategoryHandler.bind(_this);
         _this.setupCharactersAtTab = _this.setupCharactersAtTab.bind(_this);
+
+        // To-do: Update handling of refs. React 16.3+ has createRef. 16.8+ has useRef.
+        _this.bindInputRef = _this.bindInputRef.bind(_this);
+        _this.searchInput = null;
         return _this;
     }
 
@@ -88,7 +92,29 @@ var CharacterMap = function (_React$Component) {
     }, {
         key: 'componentDidMount',
         value: function componentDidMount() {
+            var _this2 = this;
+
             this.setupCharactersAtTab(0);
+
+            // Focus search input on mount.
+            if (this.searchInput && 'focus' in this.searchInput) {
+                // This is more reliable after a short wait.
+                window.setTimeout(function () {
+                    _this2.searchInput.focus();
+                }, 25);
+            }
+        }
+
+        /**
+         * Binds the input element to the component as a ref.
+         *
+         * @param {object} element The search input element.
+         */
+
+    }, {
+        key: 'bindInputRef',
+        value: function bindInputRef(element) {
+            this.searchInput = element;
         }
 
         // Handle clicks to the characters, running the callback function.
@@ -261,7 +287,8 @@ var CharacterMap = function (_React$Component) {
                         'aria-label': 'Filter',
                         value: search,
                         onChange: this.handleSearchChange,
-                        autoComplete: false
+                        autoComplete: false,
+                        ref: this.bindInputRef
                     })
                 ),
                 '' === search && _react2.default.createElement(

--- a/dist/component/CharacterMap.js
+++ b/dist/component/CharacterMap.js
@@ -97,7 +97,7 @@ var CharacterMap = function (_React$Component) {
             this.setupCharactersAtTab(0);
 
             // Focus search input on mount.
-            if (this.searchInput && 'focus' in this.searchInput) {
+            if (false !== this.props.autofocus && this.searchInput && 'focus' in this.searchInput) {
                 // This is more reliable after a short wait.
                 window.setTimeout(function () {
                     _this2.searchInput.focus();

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -54,14 +54,13 @@ class CharacterMap extends React.Component {
         this.setupCharactersAtTab( 0 );
 
         // Focus search input on mount.
-        if ( this.searchInput && 'focus' in this.searchInput ) {
+        if ( false !== this.props.autofocus && this.searchInput && 'focus' in this.searchInput ) {
             // This is more reliable after a short wait.
             window.setTimeout( () => {
                 this.searchInput.focus();
             }, 25 );
         }
     }
-
 
     /**
      * Binds the input element to the component as a ref.

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -22,6 +22,10 @@ class CharacterMap extends React.Component {
         this.handleSearchChange = this.handleSearchChange.bind( this );
         this.clickCategoryHandler = this.clickCategoryHandler.bind( this );
         this.setupCharactersAtTab = this.setupCharactersAtTab.bind( this );
+
+        // To-do: Update handling of refs. React 16.3+ has createRef. 16.8+ has useRef.
+        this.bindInputRef = this.bindInputRef.bind( this );
+        this.searchInput = null;
     }
 
     /**
@@ -48,6 +52,24 @@ class CharacterMap extends React.Component {
 
     componentDidMount() {
         this.setupCharactersAtTab( 0 );
+
+        // Focus search input on mount.
+        if ( this.searchInput && 'focus' in this.searchInput ) {
+            // This is more reliable after a short wait.
+            window.setTimeout( () => {
+                this.searchInput.focus();
+            }, 25 );
+        }
+    }
+
+
+    /**
+     * Binds the input element to the component as a ref.
+     *
+     * @param {object} element The search input element.
+     */
+    bindInputRef( element ) {
+        this.searchInput = element;
     }
 
     // Handle clicks to the characters, running the callback function.
@@ -181,6 +203,7 @@ class CharacterMap extends React.Component {
                         value={search}
                         onChange={this.handleSearchChange}
                         autoComplete={false}
+                        ref={this.bindInputRef}
                     />
                 </ul>
                 { '' === search &&


### PR DESCRIPTION
The Insert Special Characters WordPress plugin repo has this issue: https://github.com/10up/insert-special-characters/issues/49

The suggestion is to focus the search input when the component mounts. This update implements this change. After the component mounts, the search input is selected via a `ref`, and if it's found it is focused. 

If you would prefer not to merge this change here, it would also be easy to do in the WordPress repo. We would have to break a couple of best practices (e.g., using `window` DOM selectors and depending on a certain class or element always being available in the character map component), but that would probably be all right. Just let me know.