### PR TITLE
update repo org from pallant to Dayjo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "description": "A react component for selecting ascii characters from a categorised character map",
   "main": "dist/index.js",
-  "repository": "git@github.com:pallant/react-character-map.git",
+  "repository": "git@github.com:Dayjo/react-character-map.git",
   "author": "Joel Day",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
Only a minor change and for now GitHub is redirecting correctly from this displayed link at https://www.npmjs.com/package/react-character-map but probably worth correcting ahead of any attempt to automate the npm package creation from here in GitHub.