### PR TITLE
Fix: Validate JSON files before build

### DIFF
--- a/dist/component/chars.json
+++ b/dist/component/chars.json
@@ -1115,7 +1115,7 @@
 
 
     "Greek": [
-           ,{ "entity": "&Alpha;", "hex": "&#0391;", "name": "Greek Capital Letter Alpha", "char": "Α" }
+           { "entity": "&Alpha;", "hex": "&#0391;", "name": "Greek Capital Letter Alpha", "char": "Α" }
            ,{ "entity": "&Beta;", "hex": "&#0392;", "name": "Greek Capital Letter Beta", "char": "Β" }
            ,{ "entity": "&Gamma;", "hex": "&#0393;", "name": "Greek Capital Letter Gamma", "char": "Γ" }
            ,{ "entity": "&Delta;", "hex": "&#0394;", "name": "Greek Capital Letter Delta", "char": "Δ" }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": ">=15.0 <= 16"
   },
   "scripts": {
-    "build": "babel src -d dist --copy-files"
+    "validate-json": "jsonlint src/component/*.json --quiet",
+    "build": "npm run validate-json && babel src -d dist --copy-files"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -19,6 +20,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
+    "jsonlint": "^1.6.3",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2"

--- a/src/component/chars.json
+++ b/src/component/chars.json
@@ -1115,7 +1115,7 @@
 
 
     "Greek": [
-           ,{ "entity": "&Alpha;", "hex": "&#0391;", "name": "Greek Capital Letter Alpha", "char": "Α" }
+           { "entity": "&Alpha;", "hex": "&#0391;", "name": "Greek Capital Letter Alpha", "char": "Α" }
            ,{ "entity": "&Beta;", "hex": "&#0392;", "name": "Greek Capital Letter Beta", "char": "Β" }
            ,{ "entity": "&Gamma;", "hex": "&#0393;", "name": "Greek Capital Letter Gamma", "char": "Γ" }
            ,{ "entity": "&Delta;", "hex": "&#0394;", "name": "Greek Capital Letter Delta", "char": "Δ" }


### PR DESCRIPTION
We've not finished, yet! There is a syntax issue with the JSON file which causes the failed builds. This PR fixes that syntax error and adds a linter to validate the JSON file before building.