### PR TITLE
add default button tooltip by adding title attribute in the element

### DIFF
--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -176,6 +176,7 @@ class CharacterMap extends React.Component {
                             data-entity={characters[category][p].entity}
                             data-char={characters[category][p].char}
                             data-title={characters[category][p].name}
+                            title={characters[category][p].name}
                             onClick={ ((e) => self.charClickHandler(e,characters[category][p])) }
                         >
                             {characters[category][p].char}


### PR DESCRIPTION
This PR adds default html tooltip/alt to the button by adding title attribute to the element. 

<img width="879" alt="Screenshot 2021-10-14 at 4 28 32 PM" src="https://user-images.githubusercontent.com/4090336/137304880-9576fca6-5409-4493-b585-34c91af4d385.png">

See more in:
https://github.com/10up/insert-special-characters/issues/61 
https://github.com/10up/insert-special-characters/issues/102