### PR TITLE
fix the &nbsp; character

### DIFF
--- a/src/component/chars.json
+++ b/src/component/chars.json
@@ -650,7 +650,7 @@
            ,{ "hex": "&#22F0;", "name": "UP RIGHT DIAGONAL ELLIPSIS", "char": "⋰" }
            ,{ "hex": "&#22F1;", "name": "DOWN RIGHT DIAGONAL ELLIPSIS", "char": "⋱" }
 		   ,{ "entity": "&hairsp;", "hex": "&#200A;", "name": "Hair Space", "char": " " }
-           ,{ "entity": "&nbsp;", "hex": "&#00A0;", "name": "No-Break Space", "char": " " }
+           ,{ "entity": "&nbsp;", "hex": "&#00A0;", "name": "No-Break Space", "char": " " }
            ,{ "entity": "&ensp;", "hex": "&#2002;", "name": "En Space", "char": " " }
            ,{ "entity": "&emsp;", "hex": "&#2003;", "name": "Em Space", "char": " " }
            ,{ "entity": "&thinsp;", "hex": "&#2009;", "name": "Thin Space", "char": " " }


### PR DESCRIPTION
Fixes this issue - https://github.com/10up/insert-special-characters/issues/127

<img width="682" alt="Screenshot 2022-08-14 at 7 00 37 PM" src="https://user-images.githubusercontent.com/17757960/184539467-ccd192d4-45ce-47c7-a833-2b60dba135fb.png">

