### PR TITLE
Add support for latin character search

### DIFF
--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -181,9 +181,9 @@ class CharacterMap extends React.Component {
                 if (!characters[group][character].name) {
                     return;
                 }
-                // If search string is one character long, look for names that start with that character.
+                // If search string is one character long, look for names that match that character using the pattern `LETTER {?}`.
                 if (1===search.length) {
-                    if (0 === characters[group][character].name.toLowerCase().indexOf(search.toLowerCase())) {
+                    if (new RegExp(`LETTER ${search.toUpperCase()}`).test(characters[group][character].name)) {
                         filteredCharacters['Results'].push(characters[group][character]);
                     }
                 } else {

--- a/src/component/CharacterMap.js
+++ b/src/component/CharacterMap.js
@@ -181,10 +181,19 @@ class CharacterMap extends React.Component {
                 if (!characters[group][character].name) {
                     return;
                 }
-                // If search string is one character long, look for names that match that character using the pattern `LETTER {?}`.
-                if (1===search.length) {
-                    if (new RegExp(`LETTER ${search.toUpperCase()}`).test(characters[group][character].name)) {
-                        filteredCharacters['Results'].push(characters[group][character]);
+
+                // If search string is one character long...
+                if (1 === search.length) {
+                    const characterObj = characters[group][character];
+
+                    // Look for names that start with that character.
+                    if (0 === characterObj.name.toLowerCase().indexOf(search.toLowerCase())) {
+                        filteredCharacters['Results'].push(characterObj);
+                    }
+
+                    // Look for names that match that character using the pattern `LETTER {?}`.
+                    if (new RegExp(`LETTER ${search.toUpperCase()}`).test(characterObj.name)) {
+                        filteredCharacters['Results'].push(characterObj);
                     }
                 } else {
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/10up/insert-special-characters/issues/227).

## Description / Background Context

At the moment, the search logic (**for single characters**) looks for names that start with that character. This is not effective in finding related latin characters. I have implemented this enhancement in such a way that utilises the pattern `LETTER {?}` to effectively match the related latin characters.

This PR implements this correctly and closes [#227](https://github.com/10up/insert-special-characters/issues/227).

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
4. Type in any latin character into the search field.
5. It should now match related latin characters in a more effective way.

**BEFORE**

https://github.com/user-attachments/assets/378bafa1-1374-46f9-b82e-56473af96825

---

**AFTER**

https://github.com/user-attachments/assets/1891a710-ede9-4f8b-919e-636aad25a0bc